### PR TITLE
Fix paragraph glyphs showing in the ToC

### DIFF
--- a/nbconflux/api.py
+++ b/nbconflux/api.py
@@ -21,8 +21,7 @@ def notebook_to_page(notebook_file, confluence_url, username=None, password=None
         Page URL to update with the notebook content. The page must
         already exist.
     username: str, optional
-        Confluence username. Uses the current username if not specified,
-        stripping the "p-" prefix, if present.
+        Confluence username. Uses the current username if not specified.
     password: str, optional
         Confluence password. Prompts for the password if not given.
     generate_toc: bool, optional

--- a/nbconflux/confluence.tpl
+++ b/nbconflux/confluence.tpl
@@ -208,8 +208,8 @@ unknown type  {{ cell.type }}
 
 <ac:structured-macro ac:macro-id="8250dedf-fcaa-48da-b12d-0f929c620dc4" ac:name="style" ac:schema-version="1">
     <ac:plain-text-body><![CDATA[
-        a[class="anchor-link"] {
-            display: none;
+        a.anchor-link {
+            display: none !important;
         }
         body div.output_subarea {
             max-width: none;

--- a/nbconflux/filter.py
+++ b/nbconflux/filter.py
@@ -1,7 +1,5 @@
 import re
 
-import nbconvert.filters.markdown_mistune as markdown
-
 from bleach import Cleaner
 from html5lib.filters.base import Filter
 
@@ -60,11 +58,3 @@ def sanitize_html(source):
         strip_comments=True
     ).clean(source)
     return EMPTY_TAG_REGEX.sub(r'<\1/>', html)
-
-
-def markdown2html_mistune(source):
-    """Override the nbconvert implementation to force empty tags to be XHTML
-    compliant for compatibility with Confluence storage format."""
-    return markdown.MarkdownWithMath(
-        renderer=markdown.IPythonRenderer(escape=False, use_xhtml=True),
-    ).render(source)


### PR DESCRIPTION
Regression. markdown2html is already overridden in the HTMLExporter. The separate one I implemented misses the `anchor_link_text` setting.

Few other minor cleanups along the way.