### PR TITLE
Allow table row/col span support

### DIFF
--- a/nbconflux/filter.py
+++ b/nbconflux/filter.py
@@ -19,7 +19,8 @@ ALLOWED_ATTRS = {'*': ['class'], 'a': ['href', 'title'], 'span': ['style'],
                  'ac:link': ['ac:anchor'], 'ri:page': ['ri:content-title'],
                  'ri:url': ['ri:value'], 'ac:layout-section': ['ac:type'],
                  'ac:parameter': ['ac:name'],
-                 'ac:structured-macro': ['ac:name', 'ac:schema-version']}
+                 'ac:structured-macro': ['ac:name', 'ac:schema-version'],
+                 'td': ['rowspan', 'colspan'], 'th': ['rowspan', 'colspan']}
 
 ALLOWED_STYLES = ['color', 'text-align', 'text-decoration']
 


### PR DESCRIPTION
The storage format documentation calls them out via examples
and they used to work before I added the filtering to avoid
400 errors

/cc @pgurniak