### PR TITLE
Add '--no-verify' flag to disable HTTPS cert verification

### DIFF
--- a/nbconflux/api.py
+++ b/nbconflux/api.py
@@ -6,7 +6,7 @@ from traitlets.config import Config
 
 def notebook_to_page(notebook_file, confluence_url, username=None, password=None,
                      generate_toc=True, attach_ipynb=True, enable_style=True, enable_mathjax=False,
-                     extra_labels=None):
+                     extra_labels=None, no_verify=False):
     """Transforms the given notebook file into Confluence storage format and
     updates the given Confluence URL with its content.
 
@@ -35,6 +35,8 @@ def notebook_to_page(notebook_file, confluence_url, username=None, password=None
         Include the MathJax script and configuration (default: False)
     extra_labels: list, optional
         Additional labels to add to the page (default: None)
+    no_verify: bool, optional
+        Disable HTTPS certificate verification (default: False)
     """
     if username is None:
         username = getpass.getuser()
@@ -52,6 +54,7 @@ def notebook_to_page(notebook_file, confluence_url, username=None, password=None
     c.ConfluenceExporter.enable_style = enable_style
     c.ConfluenceExporter.enable_mathjax = enable_mathjax
     c.ConfluenceExporter.extra_labels = extra_labels
+    c.ConfluenceExporter.no_verify = no_verify
 
     exporter = ConfluenceExporter(c)
     result = exporter.from_filename(notebook_file)

--- a/nbconflux/cli.py
+++ b/nbconflux/cli.py
@@ -21,6 +21,7 @@ def main(argv=None):
     parser.add_argument('--exclude-style', action='store_true', help='Do not include the Jupyter base stylesheet')
     parser.add_argument('--include-mathjax', action='store_true', help='Enable MathJax on the page')
     parser.add_argument('--extra-labels', nargs='+', type=str, help='Additional labels to add to the page')
+    parser.add_argument('--no-verify', action='store_true', help='Disable HTTP certificate verification')
 
     args = parser.parse_args(argv or sys.argv[1:])
 
@@ -54,7 +55,7 @@ def main(argv=None):
     notebook_to_page(args.notebook, args.url, username, password,
                      generate_toc=not args.exclude_toc, attach_ipynb=not args.exclude_ipynb,
                      enable_style=not args.exclude_style, enable_mathjax=args.include_mathjax,
-                     extra_labels=args.extra_labels)
+                     extra_labels=args.extra_labels, no_verify=args.no_verify)
 
 if __name__ == '__main__':
     main()

--- a/nbconflux/cli.py
+++ b/nbconflux/cli.py
@@ -21,7 +21,7 @@ def main(argv=None):
     parser.add_argument('--exclude-style', action='store_true', help='Do not include the Jupyter base stylesheet')
     parser.add_argument('--include-mathjax', action='store_true', help='Enable MathJax on the page')
     parser.add_argument('--extra-labels', nargs='+', type=str, help='Additional labels to add to the page')
-    parser.add_argument('--no-verify', action='store_true', help='Disable HTTP certificate verification')
+    parser.add_argument('--no-verify', action='store_true', help='Disable HTTPS certificate verification')
 
     args = parser.parse_args(argv or sys.argv[1:])
 

--- a/nbconflux/exporter.py
+++ b/nbconflux/exporter.py
@@ -52,6 +52,7 @@ class ConfluenceExporter(HTMLExporter):
     enable_style = Bool(config=True, default_value=True, help='Add basic Jupyter stylesheet?')
     enable_mathjax = Bool(config=True, default_value=False, help='Add MathJax to the page to render equations?')
     extra_labels = List(config=True, trait=Unicode(), help='List of additional labels to add to the page')
+    no_verify = Bool(config=True, default_value=False, help='Disable HTTPS certificate verification')
 
     @property
     def default_config(self):
@@ -159,7 +160,8 @@ class ConfluenceExporter(HTMLExporter):
             resp = requests.get('{server}/rest/api/content?title={title}&spaceKey={space}'.format(server=server,
                                                                                                   title=title,
                                                                                                   space=space),
-                                auth=(self.username, self.password)
+                                auth=(self.username, self.password),
+                                verify=not self.no_verify
                                )
             resp.raise_for_status()
             results = resp.json()['results']
@@ -191,7 +193,8 @@ class ConfluenceExporter(HTMLExporter):
         # Fetch version number from the existing page so that we can increment it by 1.
         resp = requests.get('{server}/rest/api/content/{page_id}'.format(server=self.server,
                                                                          page_id=page_id),
-                            auth=(self.username, self.password))
+                            auth=(self.username, self.password),
+                            verify=not self.no_verify)
         resp.raise_for_status()
         content = resp.json()
         version = content['version']['number']
@@ -212,7 +215,8 @@ class ConfluenceExporter(HTMLExporter):
                                    }
                                }
                             },
-                            auth=(self.username, self.password)
+                            auth=(self.username, self.password),
+                            verify=not self.no_verify
                            )
         resp.raise_for_status()
 
@@ -235,7 +239,8 @@ class ConfluenceExporter(HTMLExporter):
         resp = requests.post('{server}/rest/api/content/{page_id}/label'.format(server=self.server,
                                                                                 page_id=page_id),
                              json=[dict(prefix='global', name=label)],
-                             auth=(self.username, self.password))
+                             auth=(self.username, self.password),
+                             verify=not self.no_verify)
         resp.raise_for_status()
 
     def add_or_update_attachment(self, filename, data, resources):
@@ -267,7 +272,8 @@ class ConfluenceExporter(HTMLExporter):
                                  'X-Atlassian-Token': 'nocheck'
                              },
                              files=files,
-                             auth=(self.username, self.password))
+                             auth=(self.username, self.password),
+                             verify=not self.no_verify)
         resp.raise_for_status()
         return resp
 

--- a/nbconflux/preprocessor.py
+++ b/nbconflux/preprocessor.py
@@ -61,7 +61,10 @@ class ConfluencePreprocessor(Preprocessor):
         resources['attachments'] = {}
         while path:
             url = '{server}{path}'.format(server=self.exporter.server, path=path)
-            resp = requests.get(url, auth=(self.exporter.username, self.exporter.password))
+            resp = requests.get(url,
+                                auth=(self.exporter.username, self.exporter.password),
+                                verify=not self.exporter.no_verify
+            )
             resp.raise_for_status()
             attachments = resp.json()
             # Build a map from attachment filename to attachment ID and attachment version

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ def argv():
 
 
 def mock_notebook_to_page(notebook, url, username, password, generate_toc, attach_ipynb,
-                          enable_style, enable_mathjax, extra_labels):
+                          enable_style, enable_mathjax, extra_labels, no_verify):
     assert notebook == 'fake-notebook.ipynb'
     assert url == 'https://confluence.localhost/some/page'
     assert username == 'fake-username'
@@ -27,6 +27,7 @@ def mock_notebook_to_page(notebook, url, username, password, generate_toc, attac
     assert not enable_style
     assert enable_mathjax
     assert extra_labels == ['extra-label-1', 'extra-label-2']
+    assert not no_verify
 
 
 def test_cli_args(argv, monkeypatch):


### PR DESCRIPTION
Pass through a 'verify=False' to `requests` actions for sites with invalid/debug/internal certificate configurations